### PR TITLE
Add exists and delete support to Query

### DIFF
--- a/spec/main-spec.php
+++ b/spec/main-spec.php
@@ -25,31 +25,31 @@ function runTests() {
         expect($result)->toBe(['a' => '2']);
       });
     });
-    describe('fetch', function() use ($Connection) {
-      $query = $Connection->fetch('Select name from test where id = 1 LIMIT 1');
-      expect($query)->toBe(['name' => 'Wow']);
+    describe('MySQL Query', function() use ($Connection) {
+      describe('get', function() use ($Connection) {
+        $result = $Connection->from('test')->select('name')-> get();
+        expect($result)->toBe(['name' => 'Wow']);
+      });
+      describe('getAll', function() use ($Connection) {
+        $result = $Connection->from('test')->select('name')->limit(2)->getAll();
+        expect($result)->toBe([['name' => 'Wow'], ['name' => 'Hey']]);
+      });
+      describe('exists', function() use ($Connection) {
+        $result = $Connection->from('test')->select('name')->where('name = "Wow"')->exists();
+        expect($result)->toBe(true);
+        $result = $Connection->from('test')->select('name')->where('name = "Beep"')->exists();
+        expect($result)->toBe(false);
+      });
     });
-    describe('fetchAll', function() use ($Connection) {
-      $query = $Connection->fetchAll('Select name from test');
-      expect($query)->toBe([['name' => 'Wow'], ['name' => 'Hey']]);
-    });
-    describe('fetchCol', function() use ($Connection) {
-      $query = $Connection->fetchCol('Select name from test LIMIT 1');
-      expect($query)->toBe('Wow');
-    });
-    describe('exists', function() use ($Connection) {
-      $query = $Connection->exists('Select 1 from test where name = "Wow" LIMIT 1');
-      expect($query)->toBe(true);
-      $query = $Connection->exists('Select 1 from test where name = "Beep" LIMIT 1');
-      expect($query)->toBe(false);
-    });
-    describe('insert', function() use ($Connection) {
-      $query = $Connection->exists('Select 1 from test where name = "Beep" LIMIT 1');
-      expect($query)->toBe(false);
+    describe('insert && MySQLQuery::delete', function() use ($Connection) {
+      $result = $Connection->from('test')->select('name')->where('name = "Beep"')->exists();
+      expect($result)->toBe(false);
       $Connection->insert('test', ['name' => 'Beep']);
-      $query = $Connection->exists('Select 1 from test where name = "Beep" LIMIT 1');
-      expect($query)->toBe(true);
-      $Connection->query('Delete from test where name = "Beep"');
+      $result = $Connection->from('test')->select('name')->where('name = "Beep"')->exists();
+      expect($result)->toBe(true);
+      $Connection->from('test')->where('name = "Beep"')->delete();
+      $result = $Connection->from('test')->select('name')->where('name = "Beep"')->exists();
+      expect($result)->toBe(false);
     });
   });
 }

--- a/src/MySQL.hh
+++ b/src/MySQL.hh
@@ -23,24 +23,6 @@ class MySQL {
     }
     return $query;
   }
-  public function fetch<T>(string $statement, ?array<string, mixed> $parameters = null): ?T {
-    $result = $this->query($statement, $parameters)->fetch(PDO::FETCH_ASSOC);
-    if ($result === false) {
-      return null;
-    } else return $result;
-  }
-  public function fetchCol<T>(string $statement, ?array<string, mixed> $parameters = null): ?T {
-    $result = $this->query($statement, $parameters)->fetch(PDO::FETCH_NUM);
-    if ($result === false) {
-      return null;
-    } else return $result[0];
-  }
-  public function fetchAll<T>(string $statement, ?array<string, mixed> $parameters = null): array<T> {
-    return $this->query($statement, $parameters)->fetchAll(PDO::FETCH_ASSOC);
-  }
-  public function exists(string $statement, ?array<string, mixed> $parameters = null): bool {
-    return $this->query($statement, $parameters)->rowCount() > 0;
-  }
   public function insert(string $table, array<string, mixed> $paramters): int {
     $keys = [];
     $values = [];


### PR DESCRIPTION
We now support a beautiful query API, these are now valid

``` php
<?php
$db = magically_get_db();
$db->from('table')->where(['a' => 1])->delete();
$db->from('table')->where(['b' => 'c'])->exists();
$db->from('table')->select(['name', 'email'])->where(['id' => 1])->get()
$db->from('table')->select(['name', 'email'])->where(['id' => 1])->getAll()
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/steelbrain/pdo-mysql/5)

<!-- Reviewable:end -->
